### PR TITLE
[FIX] Prototype pollution using Object.freeze()

### DIFF
--- a/modules/utils.js
+++ b/modules/utils.js
@@ -645,7 +645,6 @@ function mergeObjectsInGecko(origin, add, opts) {
         keepReferences = options.keepReferences;
     
     // Fix prototype pollution freezing the *origin* Object
-    Object.freeze(origin.__proto__);
     Object.freeze(origin);
 
     for (var p in add) {

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -643,6 +643,10 @@ function mergeObjectsInGecko(origin, add, opts) {
 
     var options = opts || {},
         keepReferences = options.keepReferences;
+    
+    // Fix prototype pollution freezing the *origin* Object
+    Object.freeze(origin.__proto__);
+    Object.freeze(origin);
 
     for (var p in add) {
         if (isPlainObject(add[p])) {


### PR DESCRIPTION
#### Bounty URL:

### ⚙️ Description *

The `casperjs` library was vulnerable against a `prototype pollution` issue, which happened in the `mergeObjects` function manipulating the `origin` object without checking if the edited attributes were related to the `proto`.

### 💻 Technical Description *

I fixed the issue using the `Object.freeze()` function, which avoids further exploitations (read more on https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf --> `Mitigation` part).

### 🐛 Proof of Concept (PoC) *

![Screenshot from 2020-08-06 17-04-45](https://user-images.githubusercontent.com/33063403/89548240-0f393700-d807-11ea-8130-c706630d90bd.png)

### 🔥 Proof of Fix (PoF) *

Same above with the correct version

### 👍 User Acceptance Testing (UAT)

It seems all works correctly :smile: