### PR TITLE
Fixed Prototype Pollution vulnerability in casperjs

### DIFF
--- a/modules/utils.js
+++ b/modules/utils.js
@@ -690,7 +690,13 @@ function mergeObjects(origin, add, opts) {
         return mergeObjectsInGecko(origin, add, options);
     }
 
+    // Prototype pollution mitigation
     for (var p in add) {
+        var key =  String(Object.keys(add));
+        if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+            return origin;
+        }
+
         if (add[p] && add[p].constructor === Object) {
             if (origin[p] && origin[p].constructor === Object) {
                 origin[p] = mergeObjects(origin[p], add[p]);


### PR DESCRIPTION
### 📊 Metadata *

Prototype Pollution bug

#### Bounty URL:  https://www.huntr.dev/bounties/1-npm-casperjs

### ⚙️ Description *

`casperjs` is a navigation scripting & testing utility for PhantomJS and SlimerJS.
This package is vulnerable to Prototype Pollution. The `mergeObjects` utility function is vulnerable to Prototype Pollution.

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.

### 💻 Technical Description *

The bug is fixed by validating the input `Object` to check for prototypes. It is implemented by a simple validation to check for prototype keywords `(__proto__, constructor and prototype)`, where if it exists, the function returns the object without modifying it, thus fixing the Prototype Pollution Vulnerability. 

### 🐛 Proof of Concept (PoC) *

Clone the project, install the required dependencies and on running the below snippet of code, it triggers prototype pollution and logs `pwned`.
```javascript
var casper = require("casper").create();
var utils = require('utils');

var payload = JSON.parse('{"__proto__": {"a": "pwned"}}')
var cu = require('clientutils').create(utils.mergeObjects({}, payload));
console.log({}.a) // prints "pwned"
```

![before](https://user-images.githubusercontent.com/16708391/89548374-921cba80-d824-11ea-8868-4bd184370316.PNG)

### 🔥 Proof of Fix (PoF) *

After the fix is applied, it returns the object without modifying it when prototype pollution exists. Hence logging `undefined` instead of `pwned`.

![after](https://user-images.githubusercontent.com/16708391/89548589-d90ab000-d824-11ea-9b73-58be4d89dfdf.PNG)

### 👍 User Acceptance Testing (UAT)

The object is returned anyway and no breaking changes are introduced. :)
